### PR TITLE
chore: unify compiler warning options

### DIFF
--- a/lab02/Makefile
+++ b/lab02/Makefile
@@ -1,7 +1,7 @@
 UNAME_S := $(shell uname -s)
 CC=gcc
 LD=gcc
-CFLAGS=-ggdb -Wall -std=c99
+CFLAGS=-ggdb -Wall -Wpedantic -std=c99
 LDFLAGS=
 
 ifeq ($(UNAME_S), Darwin)

--- a/lab03/Makefile
+++ b/lab03/Makefile
@@ -3,7 +3,7 @@ all: bit_ops lfsr factorial list_map
 
 CC=gcc
 LD=gcc
-CFLAGS=-ggdb -Wall -std=c99
+CFLAGS=-ggdb -Wall -Wpedantic -std=c99
 LDFLAGS=
 
 lfsr: lfsr.c

--- a/lab07/Makefile
+++ b/lab07/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 LD=gcc
-CFLAGS=-ggdb -Wall -pedantic -std=gnu99 -O3
+CFLAGS=-ggdb -Wall -Wpedantic -std=gnu99 -O3
 LDFLAGS=
 
 EX2_PROG=matrixMultiply

--- a/lab09/Makefile
+++ b/lab09/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-C_FLAGS=--std=c99
+C_FLAGS=-Wall -Wpedantic --std=c99
 
 simd: simd.c common.c
 	$(CC) $(C_FLAGS) -O0 simd.c common.c -o simd

--- a/lab10/Makefile
+++ b/lab10/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-fopenmp -g -std=gnu99 -pthread
+CFLAGS=-fopenmp -g -std=gnu99 -pthread -Wall -Wpedantic 
 LDFLAGS=-fopenmp 
 
 all: v_add hello dotp


### PR DESCRIPTION
Lab07 applies most strict compiler warning options, I think we should keep consistent compiler warnings across the labs.

Personally I would also add `-Wextra`, though `-Wall -Wpedantic` is good enough.