### PR TITLE
Solve the memory leak that may lead to the failure of v_add.

### DIFF
--- a/lab10/v_add.c
+++ b/lab10/v_add.c
@@ -62,9 +62,13 @@ int verify(double* x, double* y, void (*funct)(double* x, double* y, double* z))
   }
   for (int i = 0; i < ARRAY_SIZE; i++) {
     if (z_oracle[i] != z_v_add[i]) {
+      free(z_v_add);
+      free(z_oracle);
       return 0;
     }
   }
+  free(z_v_add);
+  free(z_oracle);
   return 1;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8278439/62704274-8afa7b00-ba1d-11e9-87c0-c1d10b11446b.png)
This will happen in my Ubuntu with 4GB memory while memory allocated in function "verify" not freed.
